### PR TITLE
Add bilingual glossary for key Odoo terms

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,14 @@
+# Odoo Glossary / Odoo 术语表
+
+| English Term | 中文术语 | Explanation / 说明 |
+|--------------|----------|--------------------|
+| Odoo | Odoo | Open-source suite of business applications / 开源的业务应用集合 |
+| Module | 模块 | Independent unit providing specific business features, defined by a manifest and code / 由 manifest 和代码定义的提供特定业务功能的独立单元 |
+| Add-on | 插件 | Additional module located in the `addons` directory to extend base functionality / 位于 `addons` 目录用于扩展基础功能的附加模块 |
+| ORM | 对象关系映射 | Framework layer that maps Python objects to database tables, simplifying data access / 将 Python 对象映射到数据库表以简化数据访问的框架层 |
+| API | 应用程序接口 | Decorators and methods used to interact with models and services / 用于与模型和服务交互的装饰器和方法 |
+| odoo-bin | odoo-bin | Command-line script used to start the server and manage modules / 用于启动服务器和管理模块的命令行脚本 |
+| Manifest | 描述文件 | `__manifest__.py` describing a module's metadata and dependencies / 描述模块元数据与依赖的 `__manifest__.py` 文件 |
+| Testing | 测试 | Unit tests ensuring module stability and correctness / 确保模块稳定性与正确性的单元测试 |
+| Dependency Management | 依赖管理 | Installing required Python packages as listed in `requirements.txt` / 按 `requirements.txt` 安装所需 Python 包 |
+| Contribution Guide | 贡献指南 | Community rules for contributing code, documented in `CONTRIBUTING.md` / `CONTRIBUTING.md` 中记录的社区贡献规则 |


### PR DESCRIPTION
## Summary
- Create `GLOSSARY.md` with Chinese and English explanations of core Odoo concepts

## Testing
- `pre-commit run --files GLOSSARY.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b741490a848326bf154900c1768476